### PR TITLE
fix: check both route name and path using Laravel methods

### DIFF
--- a/src/Middleware/RestrictAccessByGeo.php
+++ b/src/Middleware/RestrictAccessByGeo.php
@@ -94,17 +94,16 @@ class RestrictAccessByGeo
     {
         $only = Config::get('geo-restrict.routes.only', []);
         $except = Config::get('geo-restrict.routes.except', []);
-        $current = $request->route()?->getName() ?? $request->path();
 
         foreach ($except as $pattern) {
-            if (fnmatch($pattern, $current)) {
+            if ($request->routeIs($pattern) || $request->is($pattern)) {
                 return false;
             }
         }
 
         if (!empty($only)) {
             foreach ($only as $pattern) {
-                if (fnmatch($pattern, $current)) {
+                if ($request->routeIs($pattern) || $request->is($pattern)) {
                     return true;
                 }
             }


### PR DESCRIPTION
- Заменена проверка fnmatch на встроенные методы Laravel: routeIs() и is()
- Теперь корректно обрабатываются настройки 'routes.only' и 'routes.except' в конфиге
- Проверка учитывает и имена маршрутов, и пути